### PR TITLE
Login now uses config for finding PlyLevelTbl.prs

### DIFF
--- a/login.go
+++ b/login.go
@@ -458,7 +458,8 @@ func (server *LoginServer) Init() {
 
 	// Load the base stats for creating new characters. Newserv, Sylverant, and Tethealla
 	// all seem to rely on this file, so we'll do the same.
-	statsFile, _ := os.Open("parameters/PlyLevelTbl.prs")
+	paramDir := config.ParametersDir
+	statsFile, _ := os.Open(paramDir + "/PlyLevelTbl.prs")
 	compressed, err := ioutil.ReadAll(statsFile)
 	if err != nil {
 		fmt.Println("Error reading stats file: " + err.Error())


### PR DESCRIPTION
LoginServer Init method is now using the parameters directory specified
in the archon config file like it should instead of a hardcoded pathname.