### PR TITLE
Renamed logrus import

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/dcrodman/archon/util"
 	_ "github.com/go-sql-driver/mysql"
 	"io"


### PR DESCRIPTION
According to the logrus package websitefor logrus (github.com/sirupsen/logrus),
"Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus.
Any package that isn't, should be changed." to prevent case-sensitive problems and maintain
compatibility.