### PR TITLE
Fixed WaitGroup early exit bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,8 +91,10 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 			os.Exit(1)
 		}
 
+		wg.Add(1)
 		go func(serv Server) {
-			wg.Add(1)
+			defer fmt.Println(serv.Name() + " shutdown.")
+			fmt.Println(serv.Name() + " running.")
 			// Poll until we can accept more clients.
 			for d.conns.Count() < config.MaxConnections {
 				conn, err := socket.AcceptTCP()

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 	}
 	// Pass through again to prevent the output from changing due to race cond.
 	for _, s := range d.servers {
-		fmt.Printf("Waiting for %s connections on %v:%v\n", s.Name(), d.host, s.Port())
+		fmt.Printf("%s will wait for connections on %v:%v\n", s.Name(), d.host, s.Port())
 	}
 	d.log.Infof("Dispatcher: Server Initialized")
 }

--- a/main.go
+++ b/main.go
@@ -94,7 +94,6 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 		wg.Add(1)
 		go func(serv Server) {
 			defer fmt.Println(serv.Name() + " shutdown.")
-			fmt.Println(serv.Name() + " running.")
 			// Poll until we can accept more clients.
 			for d.conns.Count() < config.MaxConnections {
 				conn, err := socket.AcceptTCP()
@@ -115,7 +114,7 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 	}
 	// Pass through again to prevent the output from changing due to race cond.
 	for _, s := range d.servers {
-		fmt.Printf("%s will wait for connections on %v:%v\n", s.Name(), d.host, s.Port())
+		fmt.Printf("Waiting for %s connections on %v:%v\n", s.Name(), d.host, s.Port())
 	}
 	d.log.Infof("Dispatcher: Server Initialized")
 }


### PR DESCRIPTION
On certain machines, the waitgroup in main.go would immediately exit as if no goroutines
had been running.  This appears to have to do with a misplaced "wg.Add(1)" statement.

According to the WaitGroup docs:
  Note that calls with a positive delta that occur weth the counter is zero must happen before a Wait.
  Calls with a negative delta, or calls with a positive delta that start when the counter is great than zero,
  may happen at any time.  Typically this means the calls to Add should execute before the statement
  creating the goroutine or other event to be waited for.

Additional print statements have been added for clarity, since right now, print statements claiming a server
is running will print even when said server isnt running.  Servers also, until now, would not give the user
any indication that they've been stopped.