### PR TITLE
Empty patchdir fix

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,6 +40,7 @@ import (
 // with the intent that they be considered immutable.
 type Config struct {
 	Hostname string
+	ExternalIP string
 	// Patch ports.
 	PatchPort string
 	DataPort  string
@@ -92,6 +93,7 @@ type Config struct {
 // that some configurations can remain simpler.
 var config *Config = &Config{
 	Hostname:       "127.0.0.1",
+	ExternalIP:     "127.0.0.1",
 	PatchPort:      "11000",
 	DataPort:       "11001",
 	LoginPort:      "12000",
@@ -183,7 +185,7 @@ func (config *Config) HostnameBytes() [4]byte {
 	// Hacky, but chances are the IP address isn't going to start with 0 and a
 	// fixed-length array can't be null.
 	if config.cachedHostBytes[0] == 0x00 {
-		parts := strings.Split(config.Hostname, ".")
+		parts := strings.Split(config.ExternalIP, ".")
 		for i := 0; i < 4; i++ {
 			tmp, _ := strconv.ParseUint(parts[i], 10, 8)
 			config.cachedHostBytes[i] = uint8(tmp)

--- a/config/server_config.json
+++ b/config/server_config.json
@@ -1,5 +1,6 @@
 { 
 	"Hostname" : "127.0.0.1",
+	"ExternalIP" : "127.0.0.1",
 	"PatchPort" : "11000",
 	"DataPort" : "11001",
 	"LoginPort" : "12000",

--- a/main.go
+++ b/main.go
@@ -91,8 +91,10 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 			os.Exit(1)
 		}
 
+		wg.Add(1)
 		go func(serv Server) {
-			wg.Add(1)
+			defer fmt.Println(serv.Name() + " shutdown.")
+			fmt.Println(serv.Name() + " running.")
 			// Poll until we can accept more clients.
 			for d.conns.Count() < config.MaxConnections {
 				conn, err := socket.AcceptTCP()

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 	}
 	// Pass through again to prevent the output from changing due to race cond.
 	for _, s := range d.servers {
-		fmt.Printf("Waiting for %s connections on %v:%v\n", s.Name(), d.host, s.Port())
+		fmt.Printf("%s will wait for connections on %v:%v\n", s.Name(), d.host, s.Port())
 	}
 	d.log.Infof("Dispatcher: Server Initialized")
 }

--- a/main.go
+++ b/main.go
@@ -94,7 +94,6 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 		wg.Add(1)
 		go func(serv Server) {
 			defer fmt.Println(serv.Name() + " shutdown.")
-			fmt.Println(serv.Name() + " running.")
 			// Poll until we can accept more clients.
 			for d.conns.Count() < config.MaxConnections {
 				conn, err := socket.AcceptTCP()
@@ -115,7 +114,7 @@ func (d *Dispatcher) start(wg *sync.WaitGroup) {
 	}
 	// Pass through again to prevent the output from changing due to race cond.
 	for _, s := range d.servers {
-		fmt.Printf("%s will wait for connections on %v:%v\n", s.Name(), d.host, s.Port())
+		fmt.Printf("Waiting for %s connections on %v:%v\n", s.Name(), d.host, s.Port())
 	}
 	d.log.Infof("Dispatcher: Server Initialized")
 }

--- a/patch.go
+++ b/patch.go
@@ -236,7 +236,18 @@ func (server PatchServer) Port() string { return config.PatchPort }
 
 func (server *PatchServer) Init() {
 	wd, _ := os.Getwd()
-	os.Chdir(config.PatchDir)
+
+	// Enter patch directory, making it if it doesn't exist.
+	if err := os.Chdir(config.PatchDir); err != nil {
+		if err = os.Mkdir(config.PatchDir, 0777); err != nil {
+			fmt.Println("Failed to create patch directory.")
+			os.Exit(1)
+		}
+		if err = os.Chdir(config.PatchDir); err != nil {
+			fmt.Println("Failed to enter patch directory: " + err.Error())
+			os.Exit(1)
+		}
+	}
 
 	// Construct our patch tree from the specified directory.
 	fmt.Printf("Loading patches from %s...\n", config.PatchDir)


### PR DESCRIPTION
Old code didn't check to see if a move into the patch directory was successful, using any files in
the current directory for the patch list.
New code not only tests if directory exists, but makes it (if it can) if it doesn't, and additionally
exits if it can't enter newly made patch directory.