### PR TITLE
exit processPackets when ctx is done

### DIFF
--- a/internal/server/frontend/frontend.go
+++ b/internal/server/frontend/frontend.go
@@ -151,7 +151,7 @@ func (f *Frontend) processPackets(ctx context.Context, c *server.Client) {
 		select {
 		case <-ctx.Done():
 			// For now just allow the deferred function to close the connection.
-			break
+			return
 		default:
 			if err = f.Backend.Handle(ctx, c, buffer); err != nil {
 				archon.Log.Warn("error in client communication: " + err.Error())


### PR DESCRIPTION
The initial implementation breaks from the switch statement, allowing the for loop to continue. Based on the comment, the method should exit instead.