### PR TITLE
Certgen setup fix (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The shipgate API server requires clients to connect over SSL as both a form of s
 mutual authentication. Archon includes a tool for generating these certificates, which need to be
 present in the server's config directory:
 
-    ./generate_cert
+    ./certgen
 
 The tool will prompt you for your server's external_ip (which should be the same as `external_ip`
 in `config.yaml`). You may also provide a CIDR block.

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -130,7 +130,7 @@ if [ ! -d "$INSTALL_DIR"/patches ]; then
 fi
 
 echo "Generating certificates..."
-./bin/generate_cert --ip "$SERVER_IP" > /dev/null 2>&1
+./bin/certgen --ip "$SERVER_IP" > /dev/null 2>&1
 echo "Done."
 
 echo "Adding account..."


### PR DESCRIPTION
The name of the executable for generating the certificates was changed from generate_cert to certgen [here](https://github.com/dcrodman/archon/commit/c14d76826934195614b6621494c8660ff96eef4b). Appropriate changes have been made in the setup.sh script.

This fixes #51