### PR TITLE
Fix permanently deleting soft deleted accounts

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,13 +11,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: '1.24'
       - name: Install required packages
         run: sudo apt-get update && sudo apt-get install -y libc6-dev libpcap-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.12.2

--- a/internal/shipgate/shipgate.go
+++ b/internal/shipgate/shipgate.go
@@ -177,9 +177,14 @@ func (s *ShipgateService) CreateAccount(ctx context.Context, email, username, pa
 
 // DeleteAccount deactivates an account, or deletes it from the database entirely if permanent is true.
 func (s *ShipgateService) DeleteAccount(ctx context.Context, username string, permanent bool) error {
-	account, err := findAccountByUsername(s.db, username)
+	account, err := findUnscopedAccount(s.db, username)
 	if err != nil {
 		return fmt.Errorf("finding account: %w", err)
+	}
+
+	// record not found
+	if account == nil {
+		return fmt.Errorf("no account found")
 	}
 
 	if permanent {


### PR DESCRIPTION
The accounts utility fails to permanently delete a soft deleted account because it's not using an unscoped lookup. 