### PR TITLE
Fix multiple players logging in at once

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -167,8 +167,6 @@ type JoinLobby struct {
 	Event            uint8
 	EnableVoiceChat  uint8  // No idea, always 1.
 	RandomSeed       uint32 // Only used for games.
-	// Voice chat stuff that might be specific to xbox?
-	Unused [24]uint8
 	// Player entries.
 	Entries []PlayerLobbyEntry
 }


### PR DESCRIPTION
The unused 24 bytes appears to not be necessary - I can't find it when referencing newserv's code and removing it allows a second character to log in.